### PR TITLE
CI: calling save on build result on function end.

### DIFF
--- a/ci/deamon.go
+++ b/ci/deamon.go
@@ -126,11 +126,13 @@ func StartTesterDaemon(opt DaemonOptions) {
 		r.TotalScore = 0
 	}
 
-	// saves the build results
-	if err := r.Save(); err != nil {
-		log.Println("Error saving build results:", err)
-		return
-	}
+	defer func() {
+		// saves the build results
+		if err := r.Save(); err != nil {
+			log.Println("Error saving build results:", err)
+			return
+		}
+	}()
 
 	// Build for group assignment. Stores build ID in group.
 	if opt.Group > 0 {


### PR DESCRIPTION
Fixes a issue where the build result status were reverted back to active after approval on rebuilds. 