### PR TITLE
Pendinggrouphotfix

### DIFF
--- a/entities/organisation.go
+++ b/entities/organisation.go
@@ -54,7 +54,7 @@ type Organization struct {
 	OwnerTeamID   int
 	Private       bool
 
-	GroupCount         int
+	//GroupCount         int
 	PendingGroup       map[int]interface{}
 	PendingRandomGroup map[string]interface{}
 	// TODO: change the groups field to ActiveGroups map[int]interface{}

--- a/entities/organisation_test.go
+++ b/entities/organisation_test.go
@@ -170,9 +170,9 @@ func compareOrganizations(org1, org2 *Organization, t *testing.T) {
 	if org1.Private != org2.Private {
 		t.Errorf("Two organizations do not have equal Private field. %v != %v", org1.Private, org2.Private)
 	}
-	if org1.GroupCount != org2.GroupCount {
-		t.Errorf("Two organizations do not have equal GroupCount field. %v != %v", org1.GroupCount, org2.GroupCount)
-	}
+	//if org1.GroupCount != org2.GroupCount {
+	//	t.Errorf("Two organizations do not have equal GroupCount field. %v != %v", org1.GroupCount, org2.GroupCount)
+	//}
 	if org1.CodeReview != org2.CodeReview {
 		t.Errorf("Two organizations do not have equal CodeReview field. %v != %v", org1.CodeReview, org2.CodeReview)
 	}

--- a/web/course.go
+++ b/web/course.go
@@ -693,6 +693,20 @@ func UserCoursePageHandler(w http.ResponseWriter, r *http.Request) {
 			log.Println(err)
 			return
 		}
+
+		if group.Course != orgname {
+			member.Lock()
+			opt := member.Courses[orgname]
+			opt.IsGroupMember = false
+			opt.GroupNum = 0
+			member.Courses[orgname] = opt
+			err = member.Save()
+			if err != nil {
+				log.Println(err)
+				member.Unlock()
+			}
+		}
+
 		view.Group = group
 		if group.CurrentLabNum >= org.GroupAssignments {
 			view.GroupLabnum = org.GroupAssignments - 1

--- a/web/course.go
+++ b/web/course.go
@@ -951,3 +951,18 @@ func RemoveUserHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 }
+
+// ListStudentsView is the struct used to return values from ListStudentsHandler.
+type ListStudentsView struct {
+	course string
+
+	students []*git.Member
+}
+
+// ListStudentsURL is the url used to call ListStudentsHandler.
+var ListStudentsURL = "/course/students"
+
+// ListStudentsHandler will get all the members of a course.
+func ListStudentsHandler(w http.ResponseWriter, r *http.Request) {
+
+}

--- a/web/group.go
+++ b/web/group.go
@@ -136,7 +136,7 @@ func NewGroupHandler(w http.ResponseWriter, r *http.Request) {
 		if !opt.IsGroupMember {
 			user.Lock()
 			opt.IsGroupMember = true
-			opt.GroupNum = org.GroupCount
+			opt.GroupNum = group.ID
 			user.Courses[course] = opt
 			err := user.Save()
 			if err != nil {
@@ -149,7 +149,7 @@ func NewGroupHandler(w http.ResponseWriter, r *http.Request) {
 		delete(org.PendingRandomGroup, username)
 	}
 
-	org.PendingGroup[org.GroupCount] = nil
+	org.PendingGroup[group.ID] = nil
 
 	if member.IsTeacher {
 		http.Redirect(w, r, "/course/teacher/"+org.Name+"#groups", 307)

--- a/web/group.go
+++ b/web/group.go
@@ -86,7 +86,7 @@ func NewGroupHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
-	org.GroupCount = org.GroupCount + 1
+	//org.GroupCount = org.GroupCount + 1
 
 	gid := git.GetNextGroupID()
 	if gid < 0 {

--- a/web/teacher.go
+++ b/web/teacher.go
@@ -105,10 +105,23 @@ func TeachersPanelHandler(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			log.Println(err)
 		}
+
+		if group.Course != org.Name {
+			org.Lock()
+			delete(org.PendingGroup, groupID)
+			err := org.Save()
+			if err != nil {
+				log.Println(err)
+				org.Unlock()
+			}
+			continue
+		}
+
 		for key := range group.Members {
 			groupmember, _ := git.NewMemberFromUsername(key, true)
 			group.Members[key] = groupmember
 		}
+
 		pendinggroups[groupID] = group
 	}
 


### PR DESCRIPTION
Fixes a bug where a new group in a course always starts counting from 1 and upwards as ID. This made the teachers panel and students panel showing groups from other courses, and not the newly submitted ones.  

Fixed now by starting automatic clean up when a group not belonging in the course shows up and removes the reference to this in the database. 

Close #55 